### PR TITLE
Add GitHub Codespaces support

### DIFF
--- a/.aliases.local
+++ b/.aliases.local
@@ -1,6 +1,11 @@
 # directory aliases
-alias c="cd /Users/abunashir/workspace"
-alias w="cd /Users/abunashir/workspace"
+if [[ -n "$CODESPACES" ]]; then
+  alias w="cd /workspaces"
+  alias c="cd /workspaces"
+else
+  alias w="cd $HOME/workspace"
+  alias c="cd $HOME/workspace"
+fi
 
 # digital ocean cli
 alias dlist="doctl compute droplet list"

--- a/.zshrc.local
+++ b/.zshrc.local
@@ -1,0 +1,4 @@
+# In Codespaces, replace the verbose SSH user@hostname with a short indicator
+if [[ -n "$CODESPACES" ]]; then
+  PS1="%{$fg[cyan]%}cs:%{$reset_color%}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# "
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Dotfiles install script for GitHub Codespaces (and any Debian/Ubuntu machine).
+# Installs zsh, tmux, vim and sets up thoughtbot/dotfiles + personal .local overrides.
+
+set -e
+
+DOTFILES_DIR="$HOME/dotfiles"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fancy_echo() {
+  printf "\n==> %s\n" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Packages
+# ---------------------------------------------------------------------------
+
+fancy_echo "Installing zsh, tmux, vim, and rcm..."
+sudo rm -f /etc/apt/sources.list.d/yarn.list
+sudo apt-get update -qq
+sudo apt-get install -qq -y zsh tmux vim curl git rcm
+
+# ---------------------------------------------------------------------------
+# thoughtbot/dotfiles
+# ---------------------------------------------------------------------------
+
+if [ ! -d "$DOTFILES_DIR" ]; then
+  fancy_echo "Cloning thoughtbot/dotfiles..."
+  git clone https://github.com/thoughtbot/dotfiles "$DOTFILES_DIR"
+fi
+
+fancy_echo "Patching thoughtbot dotfiles for Linux..."
+sed -i 's|eval "\$(/opt/homebrew/bin/brew shellenv)"|[ -x /opt/homebrew/bin/brew ] \&\& eval "$(/opt/homebrew/bin/brew shellenv)"|' "$DOTFILES_DIR/zshrc"
+
+fancy_echo "Running rcup..."
+env RCRC="$DOTFILES_DIR/rcrc" rcup -d "$DOTFILES_DIR" -f
+
+# ---------------------------------------------------------------------------
+# Personal .local overrides
+# ---------------------------------------------------------------------------
+
+fancy_echo "Copying personal dotfiles..."
+cp "$SCRIPT_DIR"/.*.local "$HOME/"
+
+# ---------------------------------------------------------------------------
+# vim-plug + plugins
+# ---------------------------------------------------------------------------
+
+if [ ! -f "$HOME/.vim/autoload/plug.vim" ]; then
+  fancy_echo "Installing vim-plug..."
+  curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+fi
+
+fancy_echo "Installing vim plugins..."
+vim -es -u "$HOME/.vimrc" -i NONE +PlugInstall +qall || true
+
+# ---------------------------------------------------------------------------
+# Claude Code
+# ---------------------------------------------------------------------------
+
+if command -v npm &>/dev/null; then
+  fancy_echo "Installing Claude Code..."
+  npm install -g @anthropic-ai/claude-code --silent
+fi
+
+# ---------------------------------------------------------------------------
+# Default shell
+# ---------------------------------------------------------------------------
+
+if [ "$SHELL" != "$(which zsh)" ]; then
+  fancy_echo "Setting zsh as default shell..."
+  sudo chsh -s "$(which zsh)" "$USER"
+fi
+
+fancy_echo "Done!"


### PR DESCRIPTION
Sets up a reproducible development environment in GitHub Codespaces with zsh, tmux, vim, and personal dotfiles — matching the local shell experience as closely as possible.

Previously the repo only had a heavy VM provisioning script targeting DigitalOcean. Codespaces needs a lean, automated setup that runs unattended on a standard Ubuntu container without installing full language runtimes or cloud tooling.

Changes:
- Add install.sh as the Codespaces dotfiles entrypoint: installs zsh/tmux/vim/rcm, clones thoughtbot/dotfiles, runs rcup, copies .local overrides, sets up vim-plug and plugins, and installs Claude Code via npm
- Patch thoughtbot zshrc after cloning to guard the macOS-only Homebrew path, which errors on Linux due to SSH_CONNECTION triggering the user@host prompt and the missing brew binary
- Add .zshrc.local to replace the verbose Codespaces SSH hostname with a short cyan "cs:" prefix, keeping the prompt consistent with the local shell style
- Update workspace aliases (c, w) to point to /workspaces in Codespaces and $HOME/workspace elsewhere