### PR TITLE
Fix zsh shell and prompt consistency in tmux

### DIFF
--- a/.zshrc.local
+++ b/.zshrc.local
@@ -1,4 +1,4 @@
 # In Codespaces, replace the verbose SSH user@hostname with a short indicator
 if [[ -n "$CODESPACES" ]]; then
-  PS1="%{$fg[cyan]%}cs:%{$reset_color%}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# "
+  PS1='%{$fg[cyan]%}cs:%{$reset_color%}%{$fg_bold[blue]%}%c%{$reset_color%}$(git_prompt_info) %# '
 fi

--- a/install.sh
+++ b/install.sh
@@ -72,4 +72,6 @@ if [ "$SHELL" != "$(which zsh)" ]; then
   sudo chsh -s "$(which zsh)" "$USER"
 fi
 
+echo "set-option -g default-shell $(which zsh)" >> "$HOME/.tmux.conf.local"
+
 fancy_echo "Done!"


### PR DESCRIPTION
Two issues surfaced when using tmux inside Codespaces. First, new tmux windows were falling back to bash instead of zsh. This happens because chsh updates /etc/passwd but does not change the $SHELL variable for the running session — Codespaces sets $SHELL=/bin/bash at container startup and tmux inherits it when opening new windows. Fixing this requires setting default-shell directly in tmux config, so install.sh now writes the resolved zsh path into ~/.tmux.conf.local at install time.

Second, the git branch name in the Codespaces prompt was not updating after switching branches. This was caused by using double quotes in the PS1 assignment in .zshrc.local, which evaluates $(git_prompt_info) once at shell startup and locks in the result. Switching to single quotes defers evaluation to each prompt render, which is the correct behaviour when promptsubst is active.